### PR TITLE
removes strict type checking from values.

### DIFF
--- a/src/Elements/Attributes/Attributes.php
+++ b/src/Elements/Attributes/Attributes.php
@@ -192,7 +192,7 @@ class Attributes implements Htmlable, ArrayAccess, Arrayable
 			return in_array($check_value, $current_value);
 		}
 		
-		return $current_value === $check_value;
+		return $current_value == $check_value;
 	}
 	
 	/**


### PR DESCRIPTION
Noticed that when checking "1" to 1, my radio buttons were not being set.  Removing strict value checking solved my issue.

Thoughts?