### PR TITLE
Remove unecessary dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     "illuminate/events": "5.7.*|5.8.*|6.0.*",
     "ext-json": "*",
     "graham-campbell/markdown": "^11.1",
-    "laravel/framework": "^6.0",
     "orchestra/testbench": "^4.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
   ],
   "license": "MIT",
   "require": {
-    "php": ">=7.1",
     "illuminate/support": "5.7.*|5.8.*|6.0.*",
     "illuminate/view": "5.7.*|5.8.*|6.0.*",
     "illuminate/events": "5.7.*|5.8.*|6.0.*",


### PR DESCRIPTION
This pull request removes two dependencies from `composer.json` that are unnecessary and, in one case, actively causing issues.  

My reasoning behind these changes is as follows:

- **Removing laravel/framework dependency**: I've had a look at other popular Laravel packages and none of them seem to explicitly require `laravel/framework` in their package files. I therefore thought it would be good to follow this convention in this package as well. Besides that, the explicit laravel version requirement in `composer.json` is currently actively causing issues with Laravel 6.1 instances (see Issue #40).
- **Removing PHP version requirement**: As far as I'm aware, all supported Laravel versions already require PHP versions equal to or larger than the one required in this package. Setting another explicit version requirement should therefor be superfluous.

I hope this pull request is helpful, especially since it should close #40, an issue that I tripped up with just now.