### PR TITLE
Support multiselects with name containing brackets

### DIFF
--- a/src/Elements/Select.php
+++ b/src/Elements/Select.php
@@ -19,7 +19,7 @@ class Select extends \Galahad\Aire\DTD\Select
 		
 		$this->attributes->registerMutator('name', function($name) {
 			return $this->attributes->get('multiple', false)
-				? rtrim($name, '[]').'[]'
+				? preg_replace('/\[\]$/', '', $name).'[]'
 				: $name;
 		});
 		


### PR DESCRIPTION
Method `rtrim` caused bug when the field's name looks like this:
`<select name="foo[bar]">`
`rtrim` removed the last `]` and appends the `[]` part.
The result was this: `<select name="foo[bar[]">` instead of `<select name="foo[bar][]">`
Maybe the original idea was to remove `[]` substrings from the end of the string. For this regex seems better.