### PR TITLE
Alpine.js support

### DIFF
--- a/docs/src/views/_layout.blade.php
+++ b/docs/src/views/_layout.blade.php
@@ -13,13 +13,13 @@
 	<link rel="stylesheet" href="{{ asset('aire.css') }}" />
 	
 	<link rel="stylesheet"
-	      href="https://use.fontawesome.com/releases/v5.10.1/css/solid.css"
+	      href="https://use.fontawesome.com/releases/v5.12.1/css/solid.css"
 	      crossorigin="anonymous" />
 	<link rel="stylesheet"
-	      href="https://use.fontawesome.com/releases/v5.10.1/css/brands.css"
+	      href="https://use.fontawesome.com/releases/v5.12.1/css/brands.css"
 	      crossorigin="anonymous" />
 	<link rel="stylesheet"
-	      href="https://use.fontawesome.com/releases/v5.10.1/css/fontawesome.css"
+	      href="https://use.fontawesome.com/releases/v5.12.1/css/fontawesome.css"
 	      crossorigin="anonymous" />
 	
 	@stack('head')

--- a/docs/src/views/_sidebar.blade.php
+++ b/docs/src/views/_sidebar.blade.php
@@ -24,6 +24,7 @@
 		['/', 'README', 'file'],
 		['api', 'API Overview', 'code'],
 		['working-with-elements', 'Working w/ Elements', 'layer-group'],
+		['alpine-components', 'Alpine.js', 'fab fa-js-square'],
 		['components', 'Components', 'cubes'],
 		['themes', 'Theming', 'paint-roller'],
 	];

--- a/docs/src/views/alpine-components.blade.php
+++ b/docs/src/views/alpine-components.blade.php
@@ -1,0 +1,96 @@
+@extends('_layout')
+
+@section('page-title')
+	Aire + Alpine.js
+@endsection
+
+@push('head')
+	<script src="https://unpkg.com/alpinejs@1.12.0/dist/alpine-ie11.js" defer></script>
+@endpush
+
+@section('content')
+	
+	<h1 class="text-2xl text-gray-900">
+		Aire + Alpine.js
+	</h1>
+	
+	<p>
+		Aire comes with built-in support for <a href="https://github.com/alpinejs/alpine" target="_blank">Alpine.js</a>,
+		a reactive JavaScript library built for server-generated markup. Alpine lets you add sophisticated
+		interactions to your forms without committing to a full-scale single page app. 
+	</p>
+	
+	<p>
+		All you need to do to enable Alpine integration is use the <code>asAlpineComponent()</code> method:
+	</p>
+	
+	<pre><code class="language-php">@verbatim{{ Aire::route('demo.store')->asAlpineComponent() }}@endverbatim</code></pre>
+	
+	<p>
+		This will do two things for you:
+	</p>
+	
+	<ol class="pl-8 mb-8 list-decimal">
+		<li class="my-2">
+			Set up the <code>x-data</code> attribute on your <code>{{ '<form>' }}</code> tag.
+		</li>
+		<li class="my-2">
+			Add <code>x-model</code> attributes to each of your elements.
+		</li>
+	</ol>
+	
+	<p>
+		Aire uses all the same data binding logic for <code>x-data</code>, so that you’re ready
+		to go without any additional work:
+	</p>
+	
+	<h2 class="mb-0">
+		Sample Code:
+	</h2>
+	<pre class="mt-2"><code class="language-php">@verbatim{{ Aire::open()->bind(['comment' => 'Alpine.js is great.'])->asAlpineComponent() }}
+{{ Aire::input('comment', 'Your Comment') }}
+{{ Aire::select(['5' => '5 stars', '11' => '11 stars'], 'alpine_rating')->defaultValue('5') }}
+
+&lt;div class="my-4 p-2 border rounded"&gt;
+  &lt;div class="font-bold mb-1"&gt;Preview Your Review&lt;/div&gt;
+  &lt;div class="italic text-lg font-serif"&gt;“&lt;span x-text="comment"&gt;&lt;/span&gt;”&lt;/div&gt;
+  &lt;div class="text-sm font-bold"&gt;&lt;span x-text="rating"&gt;&lt;/span&gt; stars&lt;/div&gt;
+&lt;/div&gt;
+
+{{ Aire::submit('Submit Review') }}
+{{ Aire::close() }}@endverbatim</code></pre>
+	
+	<h2 class="mb-0">
+		Resulting Form:
+	</h2>
+	<div class="border rounded p-2 my-4">
+	{{ Aire::open()->bind(['comment' => 'Alpine.js is great.'])->asAlpineComponent() }}
+	{{ Aire::input('comment', 'Your Comment') }}
+	{{ Aire::select(['5' => '5 stars', '11' => '11 stars'], 'rating')->defaultValue('5') }}
+	<div class="my-4 p-2 border rounded">
+		<div class="font-bold mb-1">Preview Your Review</div>
+		<div class="italic text-lg font-serif">“<span x-text="comment"></span>”</div>
+		<div class="text-sm font-bold"><span x-text="rating"></span> stars</div>
+	</div>
+	{{ Aire::submit('Submit Review') }}
+	{{ Aire::close() }}
+	</div>
+	
+	<h2 class="mb-0">
+		Effective HTML (just showing Alpine-specific portions):
+	</h2>
+	<pre class="mt-2"><code class="language-php">@verbatim&lt;form x-data="{'comment': 'Alpine.js is great.', 'rating': '5'}"&gt;
+&lt;input name="comment" x-model="comment" /&gt;
+&lt;select name="rating" x-model="rating"&gt;
+  &lt;option value="5"&gt;5 stars&lt;/option&gt;
+  &lt;option value="11"&gt;11 stars&lt;/option&gt;
+&lt;/select&gt;
+&lt;div class="my-4 p-2 border rounded"&gt;
+  &lt;div class="font-bold mb-1"&gt;Preview Your Review&lt;/div&gt;
+  &lt;div class="italic text-lg font-serif"&gt;“&lt;span x-text="comment"&gt;&lt;/span&gt;”&lt;/div&gt;
+  &lt;div class="text-sm font-bold"&gt;&lt;span x-text="rating"&gt;&lt;/span&gt; stars&lt;/div&gt;
+&lt;/div&gt;
+&lt;button type="submit"&gt;Submit Review&lt;/button&gt;
+&lt;/form&gt;@endverbatim</code></pre>
+
+@endsection

--- a/src/Contracts/HasJsonValue.php
+++ b/src/Contracts/HasJsonValue.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Galahad\Aire\Contracts;
+
+interface HasJsonValue
+{
+	/**
+	 * Get the value that should be used if this form element were serialized to JSON
+	 *
+	 * @return mixed
+	 */
+	public function getJsonValue();
+}

--- a/src/Elements/Checkbox.php
+++ b/src/Elements/Checkbox.php
@@ -3,10 +3,11 @@
 namespace Galahad\Aire\Elements;
 
 use Galahad\Aire\Aire;
+use Galahad\Aire\Contracts\HasJsonValue;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 
-class Checkbox extends Input
+class Checkbox extends Input implements HasJsonValue
 {
 	public $name = 'checkbox';
 	
@@ -43,9 +44,9 @@ class Checkbox extends Input
 		});
 	}
 	
-	public function getValue($default = null)
+	public function getJsonValue()
 	{
-		return true === $this->attributes->get('checked', $default);
+		return $this->attributes->get('checked');
 	}
 	
 	public function label($text) : self

--- a/src/Elements/Checkbox.php
+++ b/src/Elements/Checkbox.php
@@ -43,6 +43,11 @@ class Checkbox extends Input
 		});
 	}
 	
+	public function getValue($default = null)
+	{
+		return true === $this->attributes->get('checked', $default);
+	}
+	
 	public function label($text) : self
 	{
 		$this->view_data['label_text'] = $text;

--- a/src/Elements/CheckboxGroup.php
+++ b/src/Elements/CheckboxGroup.php
@@ -3,13 +3,15 @@
 namespace Galahad\Aire\Elements;
 
 use Galahad\Aire\Aire;
+use Galahad\Aire\Contracts\HasJsonValue;
 use Galahad\Aire\Elements\Concerns\AppliesIdToWrapper;
 use Galahad\Aire\Elements\Concerns\HasOptions;
 use Galahad\Aire\Elements\Concerns\HasValue;
+use Galahad\Aire\Elements\Concerns\MapsValueToJsonValue;
 
-class CheckboxGroup extends \Galahad\Aire\DTD\Input
+class CheckboxGroup extends \Galahad\Aire\DTD\Input implements HasJsonValue
 {
-	use HasValue, HasOptions, AppliesIdToWrapper;
+	use HasValue, HasOptions, AppliesIdToWrapper, MapsValueToJsonValue;
 	
 	public $name = 'checkbox-group';
 	

--- a/src/Elements/Concerns/MapsValueToJsonValue.php
+++ b/src/Elements/Concerns/MapsValueToJsonValue.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Galahad\Aire\Elements\Concerns;
+
+/**
+ * @property \Galahad\Aire\Elements\Attributes\Attributes $attributes
+ */
+trait MapsValueToJsonValue
+{
+	public function getJsonValue()
+	{
+		return $this->attributes->get('value');
+	}
+}

--- a/src/Elements/Element.php
+++ b/src/Elements/Element.php
@@ -149,11 +149,6 @@ abstract class Element implements Htmlable
 		return preg_replace('/\[([^\]]+)\]/m', '.$1', $name);
 	}
 	
-	public function getValue($default = null)
-	{
-		return $this->attributes->get('value', $default);
-	}
-	
 	public function setAttribute($key, $value) : self
 	{
 		$this->attributes->set($key, $value);

--- a/src/Elements/Form.php
+++ b/src/Elements/Form.php
@@ -4,6 +4,7 @@ namespace Galahad\Aire\Elements;
 
 use BadMethodCallException;
 use Galahad\Aire\Aire;
+use Galahad\Aire\Contracts\HasJsonValue;
 use Galahad\Aire\Elements\Concerns\CreatesElements;
 use Galahad\Aire\Elements\Concerns\CreatesInputTypes;
 use Illuminate\Database\Eloquent\Model;
@@ -119,7 +120,7 @@ class Form extends \Galahad\Aire\DTD\Form
 	 * 
 	 * @var array 
 	 */
-	protected $elements = [];
+	protected $json_serializable_elements = [];
 	
 	public function __construct(Aire $aire, UrlGenerator $url, Router $router = null, Store $session_store = null)
 	{
@@ -138,9 +139,8 @@ class Form extends \Galahad\Aire\DTD\Form
 	
 	public function registerElement(Element $element) : self 
 	{
-		// There should be a better way to do this, probably via HasValue-ish
-		if (!$element instanceof Group) {
-			$this->elements[] = $element;
+		if ($element instanceof HasJsonValue) {
+			$this->json_serializable_elements[] = $element;
 		}
 		
 		return $this;
@@ -225,13 +225,13 @@ class Form extends \Galahad\Aire\DTD\Form
 				return null;
 			}
 			
-			return collect($this->elements)
+			return collect($this->json_serializable_elements)
 				->reject(function(Element $element) {
 					return empty($element->getInputName());
 				})
 				->mapWithKeys(function(Element $element) {
 					$key = $element->getInputName();
-					$value = $element->getValue();
+					$value = $element->getJsonValue();
 					return [$key => $value];
 				})
 				->toJson();

--- a/src/Elements/Form.php
+++ b/src/Elements/Form.php
@@ -105,6 +105,22 @@ class Form extends \Galahad\Aire\DTD\Form
 	 */
 	protected $dev_mode = false;
 	
+	/**
+	 * If true, we'll set up x-data and x-model attributes for Alpine.js
+	 * @see https://github.com/alpinejs/alpine
+	 * 
+	 * @var bool 
+	 */
+	protected $is_alpine_component = false;
+	
+	/**
+	 * We'll store a reference to all the elements created in the form
+	 * so that if we need to serialize them for Alpine we can. 
+	 * 
+	 * @var array 
+	 */
+	protected $elements = [];
+	
 	public function __construct(Aire $aire, UrlGenerator $url, Router $router = null, Store $session_store = null)
 	{
 		parent::__construct($aire);
@@ -118,6 +134,16 @@ class Form extends \Galahad\Aire\DTD\Form
 		}
 		
 		$this->initValidation();
+	}
+	
+	public function registerElement(Element $element) : self 
+	{
+		// There should be a better way to do this, probably via HasValue-ish
+		if (!$element instanceof Group) {
+			$this->elements[] = $element;
+		}
+		
+		return $this;
 	}
 	
 	/**
@@ -180,6 +206,50 @@ class Form extends \Galahad\Aire\DTD\Form
 		}
 		
 		return $this;
+	}
+	
+	/**
+	 * Configure the form for use as an Alpine.js component
+	 * 
+	 * @see https://github.com/alpinejs/alpine
+	 * 
+	 * @param bool $alpine_component
+	 * @return $this
+	 */
+	public function asAlpineComponent(bool $alpine_component = true) : self 
+	{
+		$this->is_alpine_component = $alpine_component;
+		
+		$this->attributes->registerMutator('x-data', function() {
+			if (!$this->isAlpineComponent()) {
+				return null;
+			}
+			
+			return collect($this->elements)
+				->reject(function(Element $element) {
+					return empty($element->getInputName());
+				})
+				->mapWithKeys(function(Element $element) {
+					$key = $element->getInputName();
+					$value = $element->getValue();
+					return [$key => $value];
+				})
+				->toJson();
+		});
+		
+		return $this;
+	}
+	
+	/**
+	 * Determine whether the form is configured as an Alpine.js component
+	 * 
+	 * @see https://github.com/alpinejs/alpine
+	 * 
+	 * @return bool
+	 */
+	public function isAlpineComponent() : bool 
+	{
+		return $this->is_alpine_component;
 	}
 	
 	/**

--- a/src/Elements/Input.php
+++ b/src/Elements/Input.php
@@ -3,12 +3,14 @@
 namespace Galahad\Aire\Elements;
 
 use Galahad\Aire\Aire;
+use Galahad\Aire\Contracts\HasJsonValue;
 use Galahad\Aire\Elements\Concerns\AutoId;
 use Galahad\Aire\Elements\Concerns\HasValue;
+use Galahad\Aire\Elements\Concerns\MapsValueToJsonValue;
 
-class Input extends \Galahad\Aire\DTD\Input
+class Input extends \Galahad\Aire\DTD\Input implements HasJsonValue
 {
-	use HasValue, AutoId;
+	use HasValue, AutoId, MapsValueToJsonValue;
 	
 	protected $default_attributes = [
 		'type' => 'text',

--- a/src/Elements/RadioGroup.php
+++ b/src/Elements/RadioGroup.php
@@ -3,13 +3,15 @@
 namespace Galahad\Aire\Elements;
 
 use Galahad\Aire\Aire;
+use Galahad\Aire\Contracts\HasJsonValue;
 use Galahad\Aire\Elements\Concerns\AppliesIdToWrapper;
 use Galahad\Aire\Elements\Concerns\HasOptions;
 use Galahad\Aire\Elements\Concerns\HasValue;
+use Galahad\Aire\Elements\Concerns\MapsValueToJsonValue;
 
-class RadioGroup extends \Galahad\Aire\DTD\Input
+class RadioGroup extends \Galahad\Aire\DTD\Input implements HasJsonValue
 {
-	use HasValue, HasOptions, AppliesIdToWrapper;
+	use HasValue, HasOptions, AppliesIdToWrapper, MapsValueToJsonValue;
 	
 	public $name = 'radio-group';
 	

--- a/src/Elements/Select.php
+++ b/src/Elements/Select.php
@@ -3,13 +3,15 @@
 namespace Galahad\Aire\Elements;
 
 use Galahad\Aire\Aire;
+use Galahad\Aire\Contracts\HasJsonValue;
 use Galahad\Aire\Elements\Concerns\AutoId;
 use Galahad\Aire\Elements\Concerns\HasOptions;
 use Galahad\Aire\Elements\Concerns\HasValue;
+use Galahad\Aire\Elements\Concerns\MapsValueToJsonValue;
 
-class Select extends \Galahad\Aire\DTD\Select
+class Select extends \Galahad\Aire\DTD\Select implements HasJsonValue
 {
-	use HasValue, HasOptions, AutoId;
+	use HasValue, HasOptions, AutoId, MapsValueToJsonValue;
 	
 	public function __construct(Aire $aire, $options, Form $form = null)
 	{

--- a/src/Elements/Textarea.php
+++ b/src/Elements/Textarea.php
@@ -3,12 +3,14 @@
 namespace Galahad\Aire\Elements;
 
 use Galahad\Aire\Aire;
+use Galahad\Aire\Contracts\HasJsonValue;
 use Galahad\Aire\Elements\Concerns\AutoId;
 use Galahad\Aire\Elements\Concerns\HasValue;
+use Galahad\Aire\Elements\Concerns\MapsValueToJsonValue;
 
-class Textarea extends \Galahad\Aire\DTD\Textarea
+class Textarea extends \Galahad\Aire\DTD\Textarea implements HasJsonValue
 {
-	use HasValue, AutoId;
+	use HasValue, AutoId, MapsValueToJsonValue;
 	
 	public function __construct(Aire $aire, Form $form = null)
 	{

--- a/tests/Feature/AlpineJsTest.php
+++ b/tests/Feature/AlpineJsTest.php
@@ -1,52 +1,60 @@
 <?php
 
-/** @noinspection ReturnTypeCanBeDeclaredInspection */
-
 namespace Galahad\Aire\Tests\Feature;
 
 use Galahad\Aire\Tests\TestCase;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
+use Symfony\Component\DomCrawler\Crawler;
 
 class AlpineJsTest extends TestCase
 {
-	public function test_prior_input_is_preserved()
+	public function test_alpine_js_integration() : void
 	{
-		Session::flashInput([
+		$expected_x_data = [
 			'generic_input' => 'foo',
 			'basic_select' => 'a',
+			'text_area' => 'text',
+			'check_box' => true,
+			'checkbox_group' => ['a', 'b'],
+			'radio_group' => null,
+		];
+		
+		Session::flashInput([
+			'generic_input' => $expected_x_data['generic_input'],
+			'basic_select' => $expected_x_data['basic_select'],
 		]);
 		
 		$bound_data = [
-			'check_box' => false,
+			'check_box' => $expected_x_data['check_box'],
+			'checkbox_group' => $expected_x_data['checkbox_group'],
 		];
 		
 		ob_start();
 		
-		// This is going to be a bit of work, because the concept of "value" is really
-		// bound to the element instead of the form. We need to centralize value at the
-		// form level or find a way to register each element's value with the form on
-		// instantiation.
-		
-		$form = $this->aire()->form()->bind($bound_data)->alpine()->open();
+		$form = $this->aire()->form()->bind($bound_data)->asAlpineComponent()->open();
 		
 		echo $form->input('generic_input');
 		echo $form->select(['a' => 'a', 'b' => 'b'], 'basic_select');
-		echo $form->textArea('text_area')->defaultValue('text');
+		echo $form->textArea('text_area')->defaultValue($expected_x_data['text_area']);
 		echo $form->checkbox('check_box');
-		
-		dd(json_decode($form->attributes->get('x-data')));
+		echo $form->checkboxGroup(['a' => 'a', 'b' => 'b'], 'checkbox_group');
+		echo $form->radioGroup(['a' => 'a', 'b' => 'b'], 'radio_group');
 			
 		echo $form->close();
 		
 		$html = ob_get_clean();
 		
-		dd($html);
+		$this->assertSelectorAttribute($html, '[name=generic_input]', 'x-model', 'generic_input');
+		$this->assertSelectorAttribute($html, '[name=basic_select]', 'x-model', 'basic_select');
+		$this->assertSelectorAttribute($html, '[name=text_area]', 'x-model', 'text_area');
+		$this->assertSelectorAttribute($html, '[name=check_box]', 'x-model', 'check_box');
+		$this->assertSelectorAttribute($html, '[name="checkbox_group[]"][value=a]', 'x-model', 'checkbox_group');
+		$this->assertSelectorAttribute($html, '[name="checkbox_group[]"][value=b]', 'x-model', 'checkbox_group');
+		$this->assertSelectorAttribute($html, '[name=radio_group][value=a]', 'x-model', 'radio_group');
+		$this->assertSelectorAttribute($html, '[name=radio_group][value=b]', 'x-model', 'radio_group');
 		
-		// $this->assertSelectorAttribute($html, '#generic_input', 'value', 'foo');
-		// $this->assertSelectorAttribute($html, '#basic_select > option[value="a"]', 'selected');
-		// $this->assertSelectorAttributeMissing($html, '#basic_select > option[value="b"]', 'selected');
-		// $this->assertSelectorAttribute($html, '#multi_select > option[value="a"]', 'selected');
-		// $this->assertSelectorAttribute($html, '#multi_select > option[value="b"]', 'selected');
+		$data = (new Crawler($html))->filter('form')->attr('x-data');
+		$this->assertJsonStringEqualsJsonString(json_encode($expected_x_data), $data);
 	}
 }

--- a/tests/Feature/AlpineJsTest.php
+++ b/tests/Feature/AlpineJsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/** @noinspection ReturnTypeCanBeDeclaredInspection */
+
+namespace Galahad\Aire\Tests\Feature;
+
+use Galahad\Aire\Tests\TestCase;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Session;
+
+class AlpineJsTest extends TestCase
+{
+	public function test_prior_input_is_preserved()
+	{
+		Session::flashInput([
+			'generic_input' => 'foo',
+			'basic_select' => 'a',
+		]);
+		
+		$bound_data = [
+			'check_box' => false,
+		];
+		
+		ob_start();
+		
+		// This is going to be a bit of work, because the concept of "value" is really
+		// bound to the element instead of the form. We need to centralize value at the
+		// form level or find a way to register each element's value with the form on
+		// instantiation.
+		
+		$form = $this->aire()->form()->bind($bound_data)->alpine()->open();
+		
+		echo $form->input('generic_input');
+		echo $form->select(['a' => 'a', 'b' => 'b'], 'basic_select');
+		echo $form->textArea('text_area')->defaultValue('text');
+		echo $form->checkbox('check_box');
+		
+		dd(json_decode($form->attributes->get('x-data')));
+			
+		echo $form->close();
+		
+		$html = ob_get_clean();
+		
+		dd($html);
+		
+		// $this->assertSelectorAttribute($html, '#generic_input', 'value', 'foo');
+		// $this->assertSelectorAttribute($html, '#basic_select > option[value="a"]', 'selected');
+		// $this->assertSelectorAttributeMissing($html, '#basic_select > option[value="b"]', 'selected');
+		// $this->assertSelectorAttribute($html, '#multi_select > option[value="a"]', 'selected');
+		// $this->assertSelectorAttribute($html, '#multi_select > option[value="b"]', 'selected');
+	}
+}


### PR DESCRIPTION
This introduces an `asAlpineComponent()` method that performs all the necessary setup to use an Aire form with [Alpine.js](https://github.com/alpinejs/alpine).