### PR TITLE
Bug: Nested Old Input not found

### DIFF
--- a/src/Elements/Form.php
+++ b/src/Elements/Form.php
@@ -279,7 +279,7 @@ class Form extends \Galahad\Aire\DTD\Form implements NonInput
 		}
 		
 		// If old input is set, use that
-		if ($this->session_store && ($old = $this->session_store->getOldInput()) && Arr::exists($old, $name)) {
+		if ($this->session_store && ($old = $this->session_store->getOldInput()) && Arr::has($old, $name)) {
 			return Arr::get($old, $name) ?? '';
 		}
 		

--- a/tests/Unit/OldInputTest.php
+++ b/tests/Unit/OldInputTest.php
@@ -72,4 +72,19 @@ class OldInputTest extends TestCase
 		
 		$this->assertSelectorAttribute($input, 'input', 'value', 'baz');
 	}
+
+    public function test_nested_old_input_can_be_accessed() : void
+    {
+        $this->withSession([
+            '_old_input' => [
+                'foo' => ['bar' => ['baz' => 'foo-bar-baz']],
+            ],
+        ]);
+
+        $input = $this->aire()
+            ->form()
+            ->input('foo[bar][baz]');
+
+        $this->assertSelectorAttribute($input, 'input', 'value', 'foo-bar-baz');
+    }
 }


### PR DESCRIPTION
Swap the `exists` check for `has` since we are using dot notation.