### PR TITLE
Allow for Custom Element ID's

### DIFF
--- a/src/Elements/Concerns/AutoId.php
+++ b/src/Elements/Concerns/AutoId.php
@@ -11,6 +11,10 @@ trait AutoId
 		}
 		
 		$this->attributes->setDefault('id', function() {
+			if (self::hasMacro('customElementId')) {
+				return self::customElementId();
+			}
+			
 			$name = $this->getInputName();
 			return "__aire-{$this->form->element_id}-{$name}{$this->element_id}";
 		});


### PR DESCRIPTION
POC of #60 Addresses this feature request by me =D

usage

```php
Element::macro('customElementId', function () {
      return 'form_scheme_'.$this->getInputName());
});
```