### PR TITLE
Form 2 Inheriting Form 1 Attributes

### DIFF
--- a/src/Aire.php
+++ b/src/Aire.php
@@ -89,7 +89,7 @@ class Aire
 	/**
 	 * @var \Galahad\Aire\Elements\Form
 	 */
-	protected $form;
+	public $form;
 	
 	/**
 	 * @var array
@@ -288,9 +288,7 @@ class Aire
 			throw new BadMethodCallException('Trying to close a form before opening one.');
 		}
 		
-		$this->form->close();
-		
-		return $this->form;
+		return $this->form->close();
 	}
 	
 	/**

--- a/src/Aire.php
+++ b/src/Aire.php
@@ -89,7 +89,7 @@ class Aire
 	/**
 	 * @var \Galahad\Aire\Elements\Form
 	 */
-	public $form;
+	protected $form;
 	
 	/**
 	 * @var array
@@ -251,6 +251,10 @@ class Aire
 	public function form($action = null, $bound_data = null) : Form
 	{
 		$this->form = call_user_func($this->form_resolver);
+		
+		$this->form->onClose(function() {
+			$this->form = null;
+		});
 		
 		if ($action) {
 			$this->form->action($action);

--- a/src/Elements/Form.php
+++ b/src/Elements/Form.php
@@ -360,6 +360,8 @@ class Form extends \Galahad\Aire\DTD\Form implements NonInput
 		$this->view_data['fields'] = new HtmlString(trim(ob_get_clean()));
 		$this->opened = false;
 		
+		$this->aire->form = null;
+		
 		return $this;
 	}
 	

--- a/src/Elements/Form.php
+++ b/src/Elements/Form.php
@@ -125,6 +125,13 @@ class Form extends \Galahad\Aire\DTD\Form implements NonInput
 	 */
 	protected $json_serializable_elements = [];
 	
+	/**
+	 * Called when the form is closed
+	 * 
+	 * @var callable
+	 */
+	protected $on_close;
+	
 	public function __construct(Aire $aire, UrlGenerator $url, Router $router = null, Store $session_store = null)
 	{
 		parent::__construct($aire);
@@ -360,7 +367,9 @@ class Form extends \Galahad\Aire\DTD\Form implements NonInput
 		$this->view_data['fields'] = new HtmlString(trim(ob_get_clean()));
 		$this->opened = false;
 		
-		$this->aire->form = null;
+		if (is_callable($this->on_close)) {
+			call_user_func($this->on_close, $this);
+		}
 		
 		return $this;
 	}
@@ -537,6 +546,13 @@ class Form extends \Galahad\Aire\DTD\Form implements NonInput
 		if (is_callable([$request, 'messages'])) {
 			$this->messages($request->messages());
 		}
+		
+		return $this;
+	}
+	
+	public function onClose(callable $callback): self
+	{
+		$this->on_close = $callback;
 		
 		return $this;
 	}

--- a/tests/Unit/FormTest.php
+++ b/tests/Unit/FormTest.php
@@ -125,12 +125,32 @@ class FormTest extends TestCase
 		$form->close();
 	}
 	
-	public function test_when_opening_two_forms_the_second_form_does_not_inherit_attributes_and_classes_from_the_first_form() : void
+	public function test_when_opening_two_forms_the_second_form_does_not_inherit_attributes_and_classes_from_the_first_form_inline() : void
 	{
 		Route::get('/foo/bar')->name('demo-route');
 		
 		$form_1 = $this->aire()->route('demo-route')->setAttribute('title', 'foo-bar')->addClass('foo-class')->id('foobar-id')->close();
 		$form_2 = $this->aire()->route('demo-route')->close();
+		
+		$this->assertSelectorExists($form_1, 'form[id="foobar-id"]');
+		$this->assertSelectorExists($form_1, 'form[title="foo-bar"]');
+		$this->assertSelectorExists($form_1, 'form[class="foo-class"]');
+		
+		// Form 2 should not get the ID, Class or any other attributes from Form 1
+		$this->assertSelectorDoesNotExist($form_2, 'form[id="foobar-id"]');
+		$this->assertSelectorDoesNotExist($form_2, 'form[title="foo-bar"]');
+		$this->assertSelectorDoesNotExist($form_2, 'form[class="foo-class"]');
+	}
+	
+	public function test_when_opening_two_forms_the_second_form_does_not_inherit_attributes_and_classes_from_the_first_form_double_line() : void
+	{
+		Route::get('/foo/bar')->name('demo-route');
+		
+		$this->aire()->route('demo-route')->setAttribute('title', 'foo-bar')->addClass('foo-class')->id('foobar-id');
+		$form_1 = $this->aire()->close();
+		
+		$this->aire()->route('demo-route');
+		$form_2 = $this->aire()->close();
 		
 		$this->assertSelectorExists($form_1, 'form[id="foobar-id"]');
 		$this->assertSelectorExists($form_1, 'form[title="foo-bar"]');

--- a/tests/Unit/FormTest.php
+++ b/tests/Unit/FormTest.php
@@ -124,4 +124,21 @@ class FormTest extends TestCase
 		
 		$form->close();
 	}
+	
+	public function test_when_opening_two_forms_the_second_form_does_not_inherit_attributes_and_classes_from_the_first_form() : void
+	{
+		Route::get('/foo/bar')->name('demo-route');
+		
+		$form_1 = $this->aire()->route('demo-route')->setAttribute('title', 'foo-bar')->addClass('foo-class')->id('foobar-id')->close();
+		$form_2 = $this->aire()->route('demo-route')->close();
+		
+		$this->assertSelectorExists($form_1, 'form[id="foobar-id"]');
+		$this->assertSelectorExists($form_1, 'form[title="foo-bar"]');
+		$this->assertSelectorExists($form_1, 'form[class="foo-class"]');
+		
+		// Form 2 should not get the ID, Class or any other attributes from Form 1
+		$this->assertSelectorDoesNotExist($form_2, 'form[id="foobar-id"]');
+		$this->assertSelectorDoesNotExist($form_2, 'form[title="foo-bar"]');
+		$this->assertSelectorDoesNotExist($form_2, 'form[class="foo-class"]');
+	}
 }


### PR DESCRIPTION
@inxilpro 

Hey so I ran into this issue where if you open 2+ forms on the page with implicit open via route method it inherits form properties from from #1.

`aire()->route()` <- causing the issue
`aire()->open()->route()` <- works just fine

I wrote a test for the failing case -- I'm not sure why its doing what it's doing -- ping me if you want to dig into it!