### PR TITLE
Add `close` function to PHPDoc of facade

### DIFF
--- a/src/Support/Facades/Aire.php
+++ b/src/Support/Facades/Aire.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Galahad\Aire\Aire setIdGenerator(\Closure $id_generator)
  * @method static \Galahad\Aire\Elements\Form form($action = NULL, $bound_data = NULL)
  * @method static \Galahad\Aire\Elements\Form open($action = NULL, $bound_data = NULL)
+ * @method static \Galahad\Aire\Elements\Form close()
  * @method static \Galahad\Aire\Elements\Form route(string $route_name, $parameters = [], bool $absolute = true)
  * @method static \Galahad\Aire\Elements\Form resourceful(\Illuminate\Database\Eloquent\Model $model, $resource_name = null, $prepend_parameters = [])
  * @method static mixed config(string $key, $default = NULL)


### PR DESCRIPTION
This pull request adds the `close` function to the PHPDoc of the facade, because the function wasn't recognized:

![AireClose](https://user-images.githubusercontent.com/12856904/198889208-64f5f0af-bcb8-41be-b94f-9cb6a19f2504.png)
