### PR TITLE
chore: add support for Laravel 10.x

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,17 +9,21 @@ on:
 jobs:
   php-tests:
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
-        php: [ 7.4, 8.0, 8.1 ]
-        laravel: [ ^8.0, ^9.0 ]
+        php: [ 7.4, 8.0, 8.1, 8.2 ]
+        laravel: [ ^8.0, ^9.0, ^10.0 ]
         dependency-version: [ lowest, stable ]
         exclude:
           - php: 7.4
             laravel: ^9.0
           - laravel: ^9.0
             dependency-version: lowest
+          - php: 7.4
+            laravel: ^10.0
+          - php: 8.0
+            laravel: ^10.0
 
     name: "${{ matrix.php }} / ${{ matrix.laravel }} (${{ matrix.dependency-version }})"
 
@@ -33,11 +37,11 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, bcmath, intl, iconv
           coverage: none
-      
+
       - name: Register composer cache directory
         id: composer-cache-files-dir
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-      
+
       - name: Cache dependencies
         uses: actions/cache@v2
         with:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -24,6 +24,8 @@ jobs:
             laravel: ^10.0
           - php: 8.0
             laravel: ^10.0
+          - php: 8.2
+            laravel: ^8.0
 
     name: "${{ matrix.php }} / ${{ matrix.laravel }} (${{ matrix.dependency-version }})"
 

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
   ],
   "license": "MIT",
   "require": {
-    "illuminate/support": "~5.8.28|^6.0|^7.0|^8.0|^9.0|dev-master",
-    "illuminate/view": "~5.8.0|^6.0|^7.0|^8.0|^9.0|dev-master",
-    "illuminate/events": "~5.8.0|^6.0|^7.0|^8.0|^9.0|dev-master",
+    "illuminate/support": "~5.8.28|^6.0|^7.0|^8.0|^9.0|^10.0|dev-master",
+    "illuminate/view": "~5.8.0|^6.0|^7.0|^8.0|^9.0|^10.0|dev-master",
+    "illuminate/events": "~5.8.0|^6.0|^7.0|^8.0|^9.0|^10.0|dev-master",
     "ext-json": "*"
   },
   "require-dev": {
-    "orchestra/testbench": "^6.23|^7.0",
+    "orchestra/testbench": "^6.23|^7.0|^8.0",
     "phpunit/phpunit": "^9.5",
     "php-coveralls/php-coveralls": "^2.1",
     "guzzlehttp/guzzle": "~6.0|~7.0",
@@ -47,12 +47,12 @@
       "Galahad\\Aire\\Tests\\": "tests/"
     }
   },
-	"minimum-stability": "dev",
-	"prefer-stable": true,
-	"scripts": {
-		"fix-style": "vendor/bin/php-cs-fixer fix",
-		"check-style": "vendor/bin/php-cs-fixer fix --diff --dry-run"
-	},
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "scripts": {
+    "fix-style": "vendor/bin/php-cs-fixer fix",
+    "check-style": "vendor/bin/php-cs-fixer fix --diff --dry-run"
+  },
   "extra": {
     "laravel": {
       "providers": [


### PR DESCRIPTION
This PR adds support for Laravel 10.x which will be released this week. It also runs tests on PHP 8.2 for Laravel 9.x and 10.x.