### PR TITLE
chore: prepare for Laravel 11

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,17 +14,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.3
           extensions: dom, curl, libxml, mbstring, zip, pcntl, bcmath, intl, iconv
           coverage: pcov
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             vendor
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         env:
           COMPOSER_DISCARD_CHANGES: true
-        run: composer require --no-suggest --no-progress --no-interaction --prefer-dist --update-with-all-dependencies "laravel/framework:^8.0" "orchestra/testbench:^6.0"
+        run: composer require --no-suggest --no-progress --no-interaction --prefer-dist --update-with-all-dependencies "laravel/framework:^11.0" "orchestra/testbench:^9.0"
 
       - name: Run and publish code coverage
         uses: paambaati/codeclimate-action@v2.4.0

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         env:
           COMPOSER_DISCARD_CHANGES: true
-        run: composer require --no-suggest --no-progress --no-interaction --prefer-dist --update-with-all-dependencies "laravel/framework:^11.0" "orchestra/testbench:^9.0"
+        run: composer require --no-progress --no-interaction --prefer-dist --update-with-all-dependencies "laravel/framework:^11.0" "orchestra/testbench:^9.0"
 
       - name: Run PHP CS Fixer
         run: ./vendor/bin/php-cs-fixer fix --diff --dry-run

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -10,16 +10,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.3
           extensions: dom, curl, libxml, mbstring, zip, pcntl, bcmath, intl, iconv
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             vendor
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         env:
           COMPOSER_DISCARD_CHANGES: true
-        run: composer require --no-suggest --no-progress --no-interaction --prefer-dist --update-with-all-dependencies "laravel/framework:^8.0" "orchestra/testbench:^6.0"
+        run: composer require --no-suggest --no-progress --no-interaction --prefer-dist --update-with-all-dependencies "laravel/framework:^11.0" "orchestra/testbench:^9.0"
 
       - name: Run PHP CS Fixer
         run: ./vendor/bin/php-cs-fixer fix --diff --dry-run

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -65,4 +65,4 @@ jobs:
         run: composer update --no-interaction --prefer-dist --with-all-dependencies --prefer-${{ matrix.dependency-version }}
 
       - name: Execute tests
-        run: vendor/bin/phpunit -v
+        run: vendor/bin/phpunit

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -13,20 +13,20 @@ jobs:
     strategy:
       matrix:
         dependency-version: [ stable, lowest ]
-        laravel: [ ^8.79, ^9.50.2, 10.* ]
-        php: [ 8.0, 8.1, 8.2 ]
+        laravel: [ ^9.50.2, 10.*, 11.* ]
+        php: [ 8.1, 8.2, 8.3 ]
         include:
-          - laravel: ^8.79
-            testbench: ^6.24
           - laravel: ^9.50.2
             testbench: ^7.22
           - laravel: 10.*
             testbench: 8.*
+          - laravel: 11.*
+            testbench: 9.*
         exclude:
-          - php: 8.2
-            laravel: ^8.79
-          - php: 8.0
-            laravel: 10.*
+          - php: 8.1
+            laravel: 11.*
+          - php: 8.3
+            laravel: 9.*
           
     timeout-minutes: 10
 
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -49,7 +49,7 @@ jobs:
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT  
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             vendor

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -8,7 +8,7 @@ jobs:
   update-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: ${{ github.event.repository.full_name }}
           ref: 'main'

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   },
   "require-dev": {
     "orchestra/testbench": "^6.24|^7.10|^8|^9|10.x-dev|dev-master",
-    "phpunit/phpunit": "^9.5",
+    "phpunit/phpunit": "^9.5|^10|^11",
     "php-coveralls/php-coveralls": "^2.1",
     "guzzlehttp/guzzle": "~6.0|~7.0",
     "symfony/css-selector": "^5.4",

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
   "type": "library",
   "license": "MIT",
   "require": {
-    "illuminate/support": "~5.8.28|^6|^7|^8|^9|^10|11.x-dev|dev-master",
-    "illuminate/view": "~5.8.28|^6|^7|^8|^9|^10|11.x-dev|dev-master",
-    "illuminate/events": "~5.8.28|^6|^7|^8|^9|^10|11.x-dev|dev-master",
+    "illuminate/support": "~5.8.28|^6|^7|^8|^9|^10|^11|dev-master",
+    "illuminate/view": "~5.8.28|^6|^7|^8|^9|^10|^11|dev-master",
+    "illuminate/events": "~5.8.28|^6|^7|^8|^9|^10|^11|dev-master",
     "ext-json": "*"
   },
   "require-dev": {
-    "orchestra/testbench": "^6.24|^7.10|^8|9.x-dev|10.x-dev|dev-master",
+    "orchestra/testbench": "^6.24|^7.10|^8|^9|10.x-dev|dev-master",
     "phpunit/phpunit": "^9.5",
     "php-coveralls/php-coveralls": "^2.1",
     "guzzlehttp/guzzle": "~6.0|~7.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,26 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	bootstrap="vendor/autoload.php"
-	colors="true"
-	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
->
-	<coverage processUncoveredFiles="true">
-		<include>
-			<directory suffix=".php">./src</directory>
-		</include>
-	</coverage>
-	<testsuites>
-		<testsuite name="Tests">
-			<directory>./tests</directory>
-		</testsuite>
-	</testsuites>
-	<php>
-		<env name="APP_ENV" value="testing"/>
-		<env name="BCRYPT_ROUNDS" value="4"/>
-		<env name="CACHE_DRIVER" value="array"/>
-		<env name="SESSION_DRIVER" value="array"/>
-		<env name="QUEUE_DRIVER" value="sync"/>
-		<env name="MAIL_DRIVER" value="array"/>
-	</php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="Tests">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="BCRYPT_ROUNDS" value="4"/>
+    <env name="CACHE_DRIVER" value="array"/>
+    <env name="SESSION_DRIVER" value="array"/>
+    <env name="QUEUE_DRIVER" value="sync"/>
+    <env name="MAIL_DRIVER" value="array"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
Prepares for the Laravel 11 release next week. Runs tests on PHP 8.1-8.3 and Laravel 9-11. It also bumps various Github Actions to their latest version.