### PR TITLE
errorBag() form option

### DIFF
--- a/src/Elements/Form.php
+++ b/src/Elements/Form.php
@@ -344,7 +344,7 @@ class Form extends \Galahad\Aire\DTD\Form implements NonInput
 		}
 
 		if ($this->error_bag) {
-			$errors = $errors->{$this->error_bag};
+			$errors = $errors->getBag($this->error_bag);
 		}
 		
 		if (!$errors->has($name)) {

--- a/src/Elements/Form.php
+++ b/src/Elements/Form.php
@@ -102,6 +102,13 @@ class Form extends \Galahad\Aire\DTD\Form implements NonInput
 	 * @var string
 	 */
 	protected $form_request;
+
+	/**
+	 * Custom error bag
+	 *
+	 * @var string
+	 */
+	protected $error_bag = null;
 	
 	/**
 	 * Set to true to load development versions of JS
@@ -335,6 +342,10 @@ class Form extends \Galahad\Aire\DTD\Form implements NonInput
 		if (!$errors instanceof ViewErrorBag) {
 			return [];
 		}
+
+		if ($this->error_bag) {
+			$errors = $errors->{$this->error_bag};
+		}
 		
 		if (!$errors->has($name)) {
 			return [];
@@ -405,6 +416,13 @@ class Form extends \Galahad\Aire\DTD\Form implements NonInput
 		$this->pending_button = null;
 		
 		return $button;
+	}
+
+	public function errorBag($name): self
+	{
+		$this->error_bag = $name;
+
+		return $this;
 	}
 	
 	/**

--- a/tests/Feature/ServerValidationTest.php
+++ b/tests/Feature/ServerValidationTest.php
@@ -42,4 +42,33 @@ class ServerValidationTest extends TestCase
 		$this->assertSelectorExists($html, '[data-aire-component="errors"]');
 		$this->assertSelectorContainsText($html, '[data-aire-component="errors"]', 'The generic input field is required');
 	}
+	
+	public function test_it_respects_error_bags()
+	{
+		Route::get('/aire', function() {
+			return view('basic-form');
+		})->middleware('web');
+		
+		Route::post('/default-bag', function(Request $request) {
+			$request->validate([
+				'generic_input' => 'required',
+			]);
+		})->middleware('web');
+		
+		Route::post('/bag2', function(Request $request) {
+			$request->validateWithBag('bag2', [
+				'generic_input' => 'required',
+			]);
+		})->middleware('web');
+		
+		$this->post('/default-bag')->assertRedirect();
+		$html = $this->get('/aire')->getContent();
+
+		$this->assertSelectorClassNames($html, '#generic_input_group', 'is-invalid');
+		
+		$this->post('/bag2')->assertRedirect();
+		$html = $this->get('/aire')->getContent();
+		
+		$this->assertSelectorMissingClassNames($html, '#generic_input_group', 'is-invalid');
+	}
 }


### PR DESCRIPTION
Support for setting the error bag will make it possible to render multiple forms on a single page that have independent error handling.  As it stands, if each of those forms had -- for example -- a summary() element, they would all indicate an error if there were a validation error in any form that had been submitted.  

To link up server side validation with your Aire form, you would do the following:
$request->validateWithBag('custom_bag', [
  'somefield' => 'required'
]) 

And in Aire:
Aire::open()->errorBag('custom_bag')

Didn't add a test -- not yet setup to run tests for this project and it perhaps wasn't clear the best place for that test to live.  Maybe ServerValidationTest.php.