### PR TITLE
Add html support for helptext

### DIFF
--- a/src/Elements/Concerns/Groupable.php
+++ b/src/Elements/Concerns/Groupable.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Str;
 
 /**
  * @method \Galahad\Aire\Elements\Element label(string|Htmlable $text)
- * @method \Galahad\Aire\Elements\Element helpText(string $text)
+ * @method \Galahad\Aire\Elements\Element helpText(string|Htmlable $text)
  * @method \Galahad\Aire\Elements\Element validated($validation_state = 'valid')
  * @method \Galahad\Aire\Elements\Element valid()
  * @method \Galahad\Aire\Elements\Element invalid()

--- a/src/Elements/Group.php
+++ b/src/Elements/Group.php
@@ -4,6 +4,7 @@ namespace Galahad\Aire\Elements;
 
 use Galahad\Aire\Aire;
 use Galahad\Aire\Contracts\NonInput;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\HtmlString;
 
 class Group extends Element implements NonInput
@@ -77,7 +78,7 @@ class Group extends Element implements NonInput
 	/**
 	 * Set the group's label
 	 *
-	 * @param string|\Illuminate\Contracts\Support\Htmlable $text
+	 * @param string|Htmlable $text
 	 * @return \Galahad\Aire\Elements\Group
 	 */
 	public function label($text): self
@@ -99,8 +100,11 @@ class Group extends Element implements NonInput
 		
 		return parent::variant($variant);
 	}
-	
-	public function helpText(string $text): self
+
+    /**
+     * @param string|Htmlable $text
+     */
+	public function helpText($text): self
 	{
 		$this->view_data['help_text'] = $text;
 		

--- a/tests/Unit/GroupTest.php
+++ b/tests/Unit/GroupTest.php
@@ -3,6 +3,7 @@
 namespace Galahad\Aire\Tests\Unit;
 
 use Galahad\Aire\Tests\TestCase;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 
 class GroupTest extends TestCase
@@ -64,6 +65,16 @@ class GroupTest extends TestCase
 		
 		$this->assertSelectorTextEquals($input, 'div > small', 'Help text');
 	}
+
+    public function test_a_group_can_have_html_help_text(): void
+    {
+        $input = $this->aire()
+            ->input()
+            ->helpText(new HtmlString('Help <strong>text</strong>'))
+            ->toHtml();
+
+        $this->assertSelectorTextEquals($input, 'div > small', 'Help text');
+    }
 	
 	public function test_a_group_can_have_errors(): void
 	{


### PR DESCRIPTION
Makes the helpText accept either a string or Htmlable.