### PR TITLE
chore: add support for php 8.4

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,33 +9,25 @@ on:
 jobs:
   php-tests:
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
         dependency-version: [ stable, lowest ]
-        laravel: [ ^8.79, ^9.50.2, 10.*, 11.* ]
-        php: [ 8.0, 8.1, 8.2, 8.3 ]
+        laravel: [ ^9.50.2, 10.*, 11.* ]
+        php: [ 8.1, 8.2, 8.3, 8.4 ]
         include:
-          - laravel: ^8.79
-            testbench: ^6.24
           - laravel: ^9.50.2
             testbench: ^7.22
           - laravel: 10.*
             testbench: 8.*
           - laravel: 11.*
-            testbench: 9.x-dev
+            testbench: 9.*
         exclude:
-          - php: 8.3
-            laravel: ^8.79
-          - php: 8.2
-            laravel: ^8.79
+          - php: 8.4
+            laravel: ^9.50.2
           - php: 8.1
             laravel: 11.*
-          - php: 8.0
-            laravel: 11.*
-          - php: 8.0
-            laravel: 10.*
-    
+
     timeout-minutes: 10
 
     name: "${{ matrix.php }} / ${{ matrix.laravel }} (${{ matrix.dependency-version }})"
@@ -54,7 +46,7 @@ jobs:
       - name: Register composer cache directory
         id: composer-cache-files-dir
         run: |
-          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT  
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
         uses: actions/cache@v3

--- a/src/Aire.php
+++ b/src/Aire.php
@@ -136,7 +136,7 @@ class Aire
 		$this->form_resolver = $form_resolver;
 		$this->user_config = $config;
 		
-		$this->setIdGenerator(function(Element $element, Form $form = null) {
+		$this->setIdGenerator(function(Element $element, ?Form $form = null) {
 			$form_id = $form->element_id ?? null;
 			$element_name = $element->getInputName();
 			$element_id = $element->element_id;
@@ -184,7 +184,7 @@ class Aire
 	 * @param \Galahad\Aire\Elements\Form|null $form
 	 * @return string
 	 */
-	public function generateAutoId(Element $element, Form $form = null): string
+	public function generateAutoId(Element $element, ?Form $form = null): string
 	{
 		return (string) call_user_func($this->id_generator, $element, $form);
 	}

--- a/src/DTD/Select.php
+++ b/src/DTD/Select.php
@@ -41,7 +41,7 @@ class Select extends Element
 {
 	public $name = 'select';
 	
-	public function __construct(Aire $aire, Form $form = null)
+	public function __construct(Aire $aire, ?Form $form = null)
 	{
 		$this->view_data['options'] = new OptionsCollection();
 		

--- a/src/Elements/Attributes/ClassNames.php
+++ b/src/Elements/Attributes/ClassNames.php
@@ -68,7 +68,7 @@ class ClassNames
 	 * @param string $element_name
 	 * @param \Galahad\Aire\Elements\Element|null $element
 	 */
-	public function __construct($element_name, Element $element = null)
+	public function __construct($element_name, ?Element $element = null)
 	{
 		$this->element_name = $element_name;
 		$this->element = $element;

--- a/src/Elements/Attributes/Collection.php
+++ b/src/Elements/Attributes/Collection.php
@@ -35,7 +35,7 @@ class Collection implements Htmlable, Arrayable, ArrayAccess
 	 * @param \Galahad\Aire\Elements\Element $element
 	 * @param array|null $default_attributes
 	 */
-	public function __construct(Aire $aire, Element $element, array $default_attributes = null)
+	public function __construct(Aire $aire, Element $element, ?array $default_attributes = null)
 	{
 		$this->aire = $aire;
 		$this->element = $element;

--- a/src/Elements/Checkbox.php
+++ b/src/Elements/Checkbox.php
@@ -27,7 +27,7 @@ class Checkbox extends Input implements HasJsonValue
 	 */
 	protected $bind_value = false;
 	
-	public function __construct(Aire $aire, Form $form = null)
+	public function __construct(Aire $aire, ?Form $form = null)
 	{
 		parent::__construct($aire, $form);
 		

--- a/src/Elements/CheckboxGroup.php
+++ b/src/Elements/CheckboxGroup.php
@@ -22,7 +22,7 @@ class CheckboxGroup extends \Galahad\Aire\DTD\Input implements HasJsonValue
 		'type' => 'checkbox',
 	];
 	
-	public function __construct(Aire $aire, $options, Form $form = null)
+	public function __construct(Aire $aire, $options, ?Form $form = null)
 	{
 		parent::__construct($aire, $form);
 		

--- a/src/Elements/ClientValidation.php
+++ b/src/Elements/ClientValidation.php
@@ -46,7 +46,7 @@ class ClientValidation implements Htmlable, NonInput
 	 */
 	protected $dev_mode = false;
 	
-	public function __construct(Aire $aire, $element_id, array $rules = [], array $messages = [], string $form_request = null, $dev_mode = false)
+	public function __construct(Aire $aire, $element_id, array $rules = [], array $messages = [], ?string $form_request = null, $dev_mode = false)
 	{
 		$this->aire = $aire;
 		$this->element_id = $element_id;

--- a/src/Elements/Concerns/CreatesElements.php
+++ b/src/Elements/Concerns/CreatesElements.php
@@ -35,7 +35,7 @@ trait CreatesElements
 	 * @param string|null $label
 	 * @return \Galahad\Aire\Elements\Button
 	 */
-	public function button(string $label = null): Button
+	public function button(?string $label = null): Button
 	{
 		$button = new Button($this->aire, $this);
 		

--- a/src/Elements/Concerns/Groupable.php
+++ b/src/Elements/Concerns/Groupable.php
@@ -102,17 +102,17 @@ trait Groupable
 		$group_method = 0 === strpos($method_name, 'group')
 			? Str::camel(substr($method_name, 5))
 			: $method_name;
-		
+
 		if ($this->grouped && method_exists($this->group, $group_method)) {
 			$this->group->$group_method(...$arguments);
-			
+
 			return $this;
 		}
-		
+
 		if (static::hasMacro($method_name)) {
 			return $this->callMacro($method_name, $arguments);
 		}
-		
+
 		// @codeCoverageIgnoreStart
 		throw new BadMethodCallException(sprintf(
 			'Method %s::%s does not exist on the Element or Group.',

--- a/src/Elements/Element.php
+++ b/src/Elements/Element.php
@@ -73,7 +73,7 @@ abstract class Element implements Htmlable
 	 */
 	protected $bind_value = true;
 	
-	public function __construct(Aire $aire, Form $form = null)
+	public function __construct(Aire $aire, ?Form $form = null)
 	{
 		$this->aire = $aire;
 		$this->element_id = $aire->generateElementId();
@@ -221,7 +221,7 @@ abstract class Element implements Htmlable
 	 * @param string|null $key
 	 * @return array|mixed
 	 */
-	public function getViewData(string $key = null)
+	public function getViewData(?string $key = null)
 	{
 		if (null === $key) {
 			return $this->view_data;
@@ -245,7 +245,7 @@ abstract class Element implements Htmlable
 		return Arr::has($this->view_data, $key);
 	}
 	
-	public function when($value = null, callable $callback = null, callable $default = null)
+	public function when($value = null, ?callable $callback = null, ?callable $default = null)
 	{
 		$value = $value instanceof Closure
 			? $value($this)
@@ -270,7 +270,7 @@ abstract class Element implements Htmlable
 		return $this;
 	}
 	
-	public function unless($value = null, callable $callback = null, callable $default = null)
+	public function unless($value = null, ?callable $callback = null, ?callable $default = null)
 	{
 		$value = $value instanceof Closure
 			? $value($this)

--- a/src/Elements/Form.php
+++ b/src/Elements/Form.php
@@ -141,7 +141,7 @@ class Form extends \Galahad\Aire\DTD\Form implements NonInput
 	 */
 	protected $on_close;
 	
-	public function __construct(Aire $aire, UrlGenerator $url, Router $router = null, Store $session_store = null)
+	public function __construct(Aire $aire, UrlGenerator $url, ?Router $router = null, ?Store $session_store = null)
 	{
 		parent::__construct($aire);
 		
@@ -334,7 +334,7 @@ class Form extends \Galahad\Aire\DTD\Form implements NonInput
 	 * @param ?string $name
 	 * @return MessageBag|array
 	 */
-	public function getErrors(string $name = null)
+	public function getErrors(?string $name = null)
 	{
 		$errors = $this->session_store
 			->get('errors', new ViewErrorBag())
@@ -504,7 +504,7 @@ class Form extends \Galahad\Aire\DTD\Form implements NonInput
 	 * @param array $custom_messages
 	 * @return $this
 	 */
-	public function validate($rule_source = null, array $custom_messages = null): self
+	public function validate($rule_source = null, ?array $custom_messages = null): self
 	{
 		$this->validate = true;
 		

--- a/src/Elements/Input.php
+++ b/src/Elements/Input.php
@@ -18,7 +18,7 @@ class Input extends \Galahad\Aire\DTD\Input implements HasJsonValue
 		'type' => 'text',
 	];
 	
-	public function __construct(Aire $aire, Form $form = null)
+	public function __construct(Aire $aire, ?Form $form = null)
 	{
 		parent::__construct($aire, $form);
 		

--- a/src/Elements/Label.php
+++ b/src/Elements/Label.php
@@ -13,7 +13,7 @@ class Label extends \Galahad\Aire\DTD\Label implements NonInput
 	 */
 	public $group;
 	
-	public function __construct(Aire $aire, Group $group = null)
+	public function __construct(Aire $aire, ?Group $group = null)
 	{
 		$this->group = $group;
 		

--- a/src/Elements/RadioGroup.php
+++ b/src/Elements/RadioGroup.php
@@ -29,7 +29,7 @@ class RadioGroup extends \Galahad\Aire\DTD\Input implements HasJsonValue
 	 * @param array|\Illuminate\Support\Collection|\Illuminate\Contracts\Support\Arrayable|\Illuminate\Contracts\Support\Jsonable|\JsonSerializable|\Traversable $options
 	 * @param \Galahad\Aire\Elements\Form|null $form
 	 */
-	public function __construct(Aire $aire, $options, Form $form = null)
+	public function __construct(Aire $aire, $options, ?Form $form = null)
 	{
 		parent::__construct($aire, $form);
 		

--- a/src/Elements/Select.php
+++ b/src/Elements/Select.php
@@ -16,7 +16,7 @@ class Select extends \Galahad\Aire\DTD\Select implements HasJsonValue
 	use AutoId;
 	use MapsValueToJsonValue;
 	
-	public function __construct(Aire $aire, $options, Form $form = null)
+	public function __construct(Aire $aire, $options, ?Form $form = null)
 	{
 		parent::__construct($aire, $form);
 		

--- a/src/Elements/Summary.php
+++ b/src/Elements/Summary.php
@@ -15,7 +15,7 @@ class Summary extends Element implements NonInput
 		'verbose' => false,
 	];
 	
-	public function __construct(Aire $aire, Form $form = null)
+	public function __construct(Aire $aire, ?Form $form = null)
 	{
 		parent::__construct($aire, $form);
 		

--- a/src/Elements/Textarea.php
+++ b/src/Elements/Textarea.php
@@ -18,7 +18,7 @@ class Textarea extends \Galahad\Aire\DTD\Textarea implements HasJsonValue
 		'auto_size' => false,
 	];
 	
-	public function __construct(Aire $aire, Form $form = null)
+	public function __construct(Aire $aire, ?Form $form = null)
 	{
 		parent::__construct($aire, $form);
 		

--- a/tests/Components/FormTest.php
+++ b/tests/Components/FormTest.php
@@ -47,10 +47,10 @@ class FormTest extends ComponentTestCase
 	public function test_action_attribute_can_be_set(): void
 	{
 		$value = Str::random();
-		
+
 		$form = $this->renderBlade('<x-aire::form :action="$value" />', compact('value'));
 		$this->assertSelectorAttribute($form, 'form', 'action', $value);
-		
+
 		// Action is special so it cannot be unset
 	}
 	
@@ -265,10 +265,10 @@ class FormTest extends ComponentTestCase
 	{
 		$form = $this->renderBlade('<x-aire::form method="get" />');
 		$this->assertSelectorAttribute($form, 'form', 'method', 'GET');
-		
+
 		$form = $this->renderBlade('<x-aire::form method="post" />');
 		$this->assertSelectorAttribute($form, 'form', 'method', 'POST');
-		
+
 		// Method cannot be unset
 	}
 	

--- a/tests/Constraints/SelectorAttribute.php
+++ b/tests/Constraints/SelectorAttribute.php
@@ -19,7 +19,7 @@ class SelectorAttribute extends CrawlerConstraint
 	 */
 	protected $value;
 	
-	public function __construct(string $selector, string $attribute, string $value = null)
+	public function __construct(string $selector, string $attribute, ?string $value = null)
 	{
 		$this->selector = $selector;
 		$this->attribute = $attribute;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -143,7 +143,7 @@ abstract class TestCase extends Orchestra
 		$this->assertStringNotContainsString($text, trim($actual));
 	}
 	
-	protected function assertSelectorAttribute($html, string $selector, string $attribute, string $value = null)
+	protected function assertSelectorAttribute($html, string $selector, string $attribute, ?string $value = null)
 	{
 		static::assertThat($html, new SelectorAttribute($selector, $attribute, $value));
 	}

--- a/tests/Unit/AutoIdTest.php
+++ b/tests/Unit/AutoIdTest.php
@@ -33,7 +33,7 @@ class AutoIdTest extends TestCase
 	
 	public function test_auto_id_can_be_user_defined(): void
 	{
-		$this->aire()->setIdGenerator(function(Element $element, Form $form = null) {
+		$this->aire()->setIdGenerator(function(Element $element, ?Form $form = null) {
 			return "foo-{$element->getInputName()}";
 		});
 		


### PR DESCRIPTION
This PR resolves deprecation warnings when using this with PHP 8.4. The changes are backwards compatible.

The Github workflow is adjusted: it runs tests from PHP 8.1 until PHP 8.4 with Laravel 9, 10 and 11. It drops tests for Laravel 8 and PHP 8.0, both no longer supported by their maintainers. It's still possible to install this package on those versions as the composer constraints are not changed.